### PR TITLE
Add missing service references for SimpliTV/ORS Austria (Astra 19.2°E)

### DIFF
--- a/rytec.channels-sat.xml
+++ b/rytec.channels-sat.xml
@@ -4596,6 +4596,7 @@
 <channel id="OrangeSport4.ro">1:0:19:19B:3:1C:1860000:0:0:0:</channel>
 <channel id="ORF1.at">1:0:19:132F:3EF:1:C00000:0:0:0:</channel>
 <channel id="ORF1.at">1:0:19:6D:3264:13E:820000:0:0:0:</channel>
+<channel id="ORF1.at">1:0:19:2EE1:78:DE:FFFF0000:0:0:0:</channel>
 <channel id="ORF1.svn">1:0:1:132F:3EF:1:C00000:0:0:0:</channel>
 <channel id="ORF1.svn">1:0:1:2775:1F4:2028:EEEE0000:0:0:0:</channel>
 <channel id="ORF2.at">1:0:19:1330:3EF:1:C00000:0:0:0:</channel>
@@ -4609,11 +4610,14 @@
 <channel id="ORF2.at">1:0:19:33FB:3ED:1:C00000:0:0:0:</channel>
 <channel id="ORF2.at">1:0:19:6E:3264:13E:820000:0:0:0:</channel>
 <channel id="ORF2.svn">1:0:1:2780:1F4:2028:EEEE0000:0:0:0:</channel>
+<channel id="ORF2.at">1:0:19:2EE2:78:DE:FFFF0000:0:0:0:</channel>
 <channel id="ORF2.svn">1:0:1:2794:1F4:2028:EEEE0000:0:0:0:</channel>
 <channel id="ORF2europe.at">1:0:16:33FE:3ED:1:C00000:0:0:0:</channel>
 <channel id="ORF3.at">1:0:19:33FC:3ED:1:C00000:0:0:0:</channel>
 <channel id="ORF3.at">1:0:19:74:3264:13E:820000:0:0:0:</channel>
+<channel id="ORF3.at">1:0:19:2EE3:78:DE:FFFF0000:0:0:0:</channel>
 <channel id="ORFSport.at">1:0:19:33FD:3ED:1:C00000:0:0:0:</channel>
+<channel id="ORFSport.at">1:0:19:3074:7C:DE:FFFF0000:0:0:0:</channel>
 <channel id="Orler.it">1:0:1:232d:2328:13e:820000:0:0:0:</channel>
 <channel id="Orler.it">1:0:16:1c0f:384:110:5a0000:0:0:0:</channel>
 <channel id="Orler.it">1:0:16:1c0f:384:110:eeee0000:0:0:0:</channel>
@@ -5885,6 +5889,7 @@
 <channel id="ServusTV.at">1:0:1:3337:45B:1:C00000:0:0:0:</channel>
 <channel id="ServusTV.at">1:0:19:1331:3EF:1:C00000:0:0:0:</channel>
 <channel id="ServusTV.at">1:0:19:75:3264:13E:820000:0:0:0:</channel>
+<channel id="ServusTV.at">1:0:19:2EE5:78:DE:FFFF0000:0:0:0:</channel>
 <channel id="ServusTVHD.svn">1:0:1:3336:45B:1:C00000:0:0:0:</channel>
 <channel id="ServusTVHD.svn">1:0:1:3337:45B:1:C00000:0:0:0:</channel>
 <channel id="ServusTVHD.svn">1:0:19:1331:3EF:1:C00000:0:0:0:</channel>


### PR DESCRIPTION
The Austrian free-to-air HD channels via SimpliTV/ORS on Astra 19.2°E (Namespace 0xDE) are currently missing from the satellite channel mapping. This means EPG Import doesn't match data for these widely used services.

Added entries:

ORF1.at → 1:0:19:2EE1:78:DE:FFFF0000:0:0:0:
ORF2.at → 1:0:19:2EE2:78:DE:FFFF0000:0:0:0:
ORF3.at → 1:0:19:2EE3:78:DE:FFFF0000:0:0:0:
ORFSport.at → 1:0:19:3074:7C:DE:FFFF0000:0:0:0:
ServusTV.at → 1:0:19:2EE5:78:DE:FFFF0000:0:0:0:
Tested on Vu+ Zero4K, OpenViX 6.8.003.